### PR TITLE
optionally ignore mouse click events associated with touch screen click event

### DIFF
--- a/Helios/Monitor.cs
+++ b/Helios/Monitor.cs
@@ -34,6 +34,7 @@ namespace GadrocsWorkshop.Helios
         private ImageAlignment _backgroundAlignment = ImageAlignment.Stretched;
         private DisplayOrientation _orientation;
         private bool _alwaysOnTop = true;
+        private int _suppressMouseAfterTouchDuration = 0;  
 
         public Monitor()
             : this(0, 0, 1024, 768, DisplayOrientation.DMDO_DEFAULT)
@@ -178,20 +179,31 @@ namespace GadrocsWorkshop.Helios
             }
         }
 
+        public int SuppressMouseAfterTouchDuration { get => _suppressMouseAfterTouchDuration; set => _suppressMouseAfterTouchDuration = value; }
+
         #endregion
 
         public override void ReadXml(XmlReader reader)
         {
             TypeConverter cc = TypeDescriptor.GetConverter(typeof(Color));
             TypeConverter bc = TypeDescriptor.GetConverter(typeof(bool));
+            TypeConverter ic = TypeDescriptor.GetConverter(typeof(int));
 
             base.ReadXml(reader);
 
             _orientation = (DisplayOrientation)Enum.Parse(typeof(DisplayOrientation), reader.ReadElementString("Orientation"));
 
+            // REVISIT: this assumes the order of XML elements and also assumes that there are no foreign elements present
+            // and that all properties are located just ahead of the "Children" element
+
             if (reader.Name.Equals("AlwaysOnTop"))
             {
                 _alwaysOnTop = (bool)bc.ConvertFromInvariantString(reader.ReadElementString("AlwaysOnTop"));
+            }
+
+            if (reader.Name.Equals("SuppressMouseAfterTouchDuration"))
+            {
+                _suppressMouseAfterTouchDuration = (int)ic.ConvertFromInvariantString(reader.ReadElementString("SuppressMouseAfterTouchDuration"));
             }
 
             if (!reader.IsEmptyElement)
@@ -228,11 +240,13 @@ namespace GadrocsWorkshop.Helios
         {
             TypeConverter cc = TypeDescriptor.GetConverter(typeof(Color));
             TypeConverter bc = TypeDescriptor.GetConverter(typeof(bool));
+            TypeConverter ic = TypeDescriptor.GetConverter(typeof(int));
 
             base.WriteXml(writer);
 
             writer.WriteElementString("Orientation", Orientation.ToString());
             writer.WriteElementString("AlwaysOnTop", bc.ConvertToInvariantString(AlwaysOnTop));
+            writer.WriteElementString("SuppressMouseAfterTouchDuration", ic.ConvertToInvariantString(_suppressMouseAfterTouchDuration));
 
             writer.WriteStartElement("Background");
             if (!string.IsNullOrWhiteSpace(BackgroundImage))

--- a/Helios/Windows/Controls/HeliosVisualView.cs
+++ b/Helios/Windows/Controls/HeliosVisualView.cs
@@ -24,6 +24,7 @@ namespace GadrocsWorkshop.Helios.Windows.Controls
     public class HeliosVisualView : FrameworkElement
     {
         private List<HeliosVisualView> _children;
+        private DateTime? _touchDownTime;
 
         public HeliosVisualView()
         {
@@ -302,7 +303,7 @@ namespace GadrocsWorkshop.Helios.Windows.Controls
                     }
                     else
                     {
-                        view = Children[viewIndex];                        
+                        view = Children[viewIndex];
                         RemoveVisualChild(view);
                         if (viewIndex != i)
                         {
@@ -379,7 +380,7 @@ namespace GadrocsWorkshop.Helios.Windows.Controls
             if (Visual != null)
             {
                 double myWidth = DisplayRotation ? Visual.Width : Visual.Width;
-                double myHeight = DisplayRotation ? Visual.Height : Visual.Height; 
+                double myHeight = DisplayRotation ? Visual.Height : Visual.Height;
 
                 double scaleX = finalSize.Width / myWidth;
                 double scaleY = finalSize.Height / myHeight;
@@ -420,10 +421,32 @@ namespace GadrocsWorkshop.Helios.Windows.Controls
             return null;
         }
 
+        private bool SuppressMouseClick()
+        {
+            if ((Visual == null) ||
+                (Visual.Monitor == null) ||
+                (Visual.Monitor.SuppressMouseAfterTouchDuration < 1) ||
+                (!_touchDownTime.HasValue))
+            {
+                return false;
+            }
+            TimeSpan since = DateTime.Now - _touchDownTime.Value;
+            if (since.TotalMilliseconds > Visual.Monitor.SuppressMouseAfterTouchDuration)
+            {
+                return false;
+            }
+            return true;
+        }
+
         protected override void OnMouseDown(System.Windows.Input.MouseButtonEventArgs e)
         {
             if (this.IsEnabled)
             {
+                if (SuppressMouseClick())
+                {
+                    e.Handled = true;
+                    return;
+                }
                 Point location = e.GetPosition(this);
                 Visual.MouseDown(location);
                 CaptureMouse();
@@ -435,6 +458,7 @@ namespace GadrocsWorkshop.Helios.Windows.Controls
         {
             if (this.IsEnabled)
             {
+                _touchDownTime = DateTime.Now;
                 Point location = e.GetTouchPoint(this).Position;
                 Visual.MouseDown(location);
                 CaptureTouch(e.TouchDevice);
@@ -466,6 +490,11 @@ namespace GadrocsWorkshop.Helios.Windows.Controls
         {
             if (e.MouseDevice.Captured == this)
             {
+                if (SuppressMouseClick())
+                {
+                    e.Handled = true;
+                    return;
+                }
                 Point location = e.GetPosition(this);
                 Visual.MouseUp(location);
                 e.MouseDevice.Capture(null);

--- a/Profile Editor/PropertyEditors/MonitorPropertyEditor.xaml
+++ b/Profile Editor/PropertyEditors/MonitorPropertyEditor.xaml
@@ -50,24 +50,31 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="0" Margin="4,10,2,2" FontSize="12" FontWeight="Bold">Behavior</TextBlock>
         
         <Label Grid.Column="0" Grid.Row="1" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top">Always On Top</Label>
         <CheckBox Grid.Column="1" Grid.Row="1" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,6,6,6" IsChecked="{Binding Control.AlwaysOnTop}" />
 
-        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="3" Margin="4,10,2,2" FontSize="12" FontWeight="Bold">Background</TextBlock>
+        <Label Grid.Column="0" Grid.Row="2" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top">Touch Click suppresses Mouse for</Label>
+        <StackPanel Grid.Column="1" Grid.Row="2" Orientation="Horizontal">
+            <TextBox HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,6,6,6" Text="{Binding Control.SuppressMouseAfterTouchDuration}" />
+            <Label FontSize="10" HorizontalAlignment="Left" VerticalAlignment="Top">ms</Label>
+        </StackPanel>
 
-        <Label Grid.Column="0" Grid.Row="4" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top">Fill</Label>        
+        <TextBlock Grid.Column="0" Grid.ColumnSpan="2" Grid.Row="4" Margin="4,10,2,2" FontSize="12" FontWeight="Bold">Background</TextBlock>
+
+        <Label Grid.Column="0" Grid.Row="5" FontSize="10" HorizontalAlignment="Right" VerticalAlignment="Top">Fill</Label>        
         
-        <StackPanel Grid.Row="4" Grid.Column="1" Orientation="Horizontal">
+        <StackPanel Grid.Row="5" Grid.Column="1" Orientation="Horizontal">
             <CheckBox HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,6,6,6" IsChecked="{Binding Control.FillBackground}" />        
             <HeliosSdk:ColorWell Color="{Binding Control.BackgroundColor,Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Left" Margin="0,2" Style="{StaticResource FillStyle}" />
         </StackPanel>
         
-        <Label Grid.Column="0" Grid.Row="5" FontSize="10" HorizontalAlignment="Right">Image</Label>
-        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="5" ImageFilename="{Binding Control.BackgroundImage, Mode=TwoWay}" />
-        <Label Grid.Column="0" Grid.Row="6" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelImageStyle}">Alignment</Label>
-        <ComboBox Grid.Column="1" Grid.Row="6" FontSize="10" Margin="0,2,0,2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource AlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Control.BackgroundAlignment, Converter={StaticResource AlignmentTypes}}" Style="{StaticResource ComboImageStyle}" />
+        <Label Grid.Column="0" Grid.Row="6" FontSize="10" HorizontalAlignment="Right">Image</Label>
+        <HeliosSdk:ImagePicker Grid.Column="1" Grid.Row="6" ImageFilename="{Binding Control.BackgroundImage, Mode=TwoWay}" />
+        <Label Grid.Column="0" Grid.Row="7" FontSize="10" HorizontalAlignment="Right" Style="{StaticResource LabelImageStyle}">Alignment</Label>
+        <ComboBox Grid.Column="1" Grid.Row="7" FontSize="10" Margin="0,2,0,2" HorizontalAlignment="Left" ItemsSource="{Binding Source={StaticResource AlignmentTypes}, Path=DisplayNames}" SelectedItem="{Binding Control.BackgroundAlignment, Converter={StaticResource AlignmentTypes}}" Style="{StaticResource ComboImageStyle}" />
     </Grid>
 </HeliosSdk:HeliosPropertyEditor>


### PR DESCRIPTION
suppression of mouse after touch click is a configurable profile option for each monitor, affecting all the controls on that monitor
configuration parameter sets number of milliseconds to ignore mouse down and mouse up after a touch down event on the same control, with 0 being disabled
this works around problems with a touch screen that generates mouse events for each touch
event, resulting in triggering controls twice for every touch

this problem was observed with an ASUS VT168H using default Windows 10 drivers and configuration