### PR TITLE
Fixes for Falcon BMS Altimeter Gauge pressure readout

### DIFF
--- a/Helios/Gauges/F-16/Altimeter/Altimeter.cs
+++ b/Helios/Gauges/F-16/Altimeter/Altimeter.cs
@@ -76,7 +76,8 @@ namespace GadrocsWorkshop.Helios.Gauges.F_16.Altimeter
 
         void AirPressure_Execute(object action, HeliosActionEventArgs e)
         {
-            _airPressureDrum.Value = e.Value.DoubleValue * 100d;
+            //_airPressureDrum.Value = e.Value.DoubleValue * 100d;
+            _airPressureDrum.Value = e.Value.DoubleValue;
         }
     }
 }

--- a/Helios/Interfaces/Falcon/BMS/BMSFalconDataExporter.cs
+++ b/Helios/Interfaces/Falcon/BMS/BMSFalconDataExporter.cs
@@ -74,7 +74,8 @@ namespace GadrocsWorkshop.Helios.Interfaces.Falcon.BMS
                     altitidue = 99999.99f - _lastFlightData.z;
                 }
                 SetValue("Altimeter", "altitidue", new BindingValue(altitidue));
-                SetValue("Altimeter", "barimetric pressure", new BindingValue(29.92));
+                //SetValue("Altimeter", "barimetric pressure", new BindingValue(29.92));
+                SetValue("Altimeter", "barimetric pressure", new BindingValue(_lastFlightData2.AltCalReading));
                 SetValue("ADI", "pitch", new BindingValue(_lastFlightData.pitch));
                 SetValue("ADI", "roll", new BindingValue(_lastFlightData.roll));
                 SetValue("ADI", "ils horizontal", new BindingValue((_lastFlightData.AdiIlsHorPos / 2.5f) - 1f));

--- a/Helios/Interfaces/Falcon/BMS/BMSFalconDataExporter.cs
+++ b/Helios/Interfaces/Falcon/BMS/BMSFalconDataExporter.cs
@@ -68,14 +68,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.Falcon.BMS
             {
                 _lastFlightData = (FlightData)_sharedMemory.MarshalTo(typeof(FlightData));
 
-                float altitidue = _lastFlightData.z;
-                if (_lastFlightData.z < 0)
-                {
-                    altitidue = 99999.99f - _lastFlightData.z;
-                }
-                SetValue("Altimeter", "altitidue", new BindingValue(altitidue));
-                //SetValue("Altimeter", "barimetric pressure", new BindingValue(29.92));
-                SetValue("Altimeter", "barimetric pressure", new BindingValue(_lastFlightData2.AltCalReading));
+                SetValue("Altimeter", "altitidue", new BindingValue(Math.Abs(_lastFlightData.z)));
                 SetValue("ADI", "pitch", new BindingValue(_lastFlightData.pitch));
                 SetValue("ADI", "roll", new BindingValue(_lastFlightData.roll));
                 SetValue("ADI", "ils horizontal", new BindingValue((_lastFlightData.AdiIlsHorPos / 2.5f) - 1f));
@@ -125,15 +118,18 @@ namespace GadrocsWorkshop.Helios.Interfaces.Falcon.BMS
                 ProcessLightBits3(_lastFlightData.lightBits3);
 
                 ProcessContacts(_lastFlightData);
-
+            }
+            if(_sharedMemory2 != null & _sharedMemory2.IsDataAvailable)
+            {
                 _lastFlightData2 = (FlightData2)_sharedMemory2.MarshalTo(typeof(FlightData2));
-                SetValue("Altimeter", "indicated altitude", new BindingValue(-_lastFlightData2.aauz));
+                SetValue("Altimeter", "indicated altitude", new BindingValue(Math.Abs(_lastFlightData2.aauz)));
+                SetValue("Altimeter", "barimetric pressure", new BindingValue(_lastFlightData2.AltCalReading));
+
                 SetValue("HSI", "nav mode", new BindingValue(_lastFlightData2.navMode));
                 SetValue("Tacan", "ufc tacan band", new BindingValue(_lastFlightData2.tacanInfo[(int)TacanSources.UFC].HasFlag(TacanBits.band) ? 1 : 2));
                 SetValue("Tacan", "aux tacan band", new BindingValue(_lastFlightData2.tacanInfo[(int)TacanSources.AUX].HasFlag(TacanBits.mode) ? 2 : 1));
                 SetValue("Tacan", "ufc tacan mode", new BindingValue(_lastFlightData2.tacanInfo[(int)TacanSources.UFC].HasFlag(TacanBits.band) ? 1 : 2));
                 SetValue("Tacan", "aux tacan mode", new BindingValue(_lastFlightData2.tacanInfo[(int)TacanSources.AUX].HasFlag(TacanBits.mode) ? 2 : 1));
-
             }
         }
 

--- a/Helios/Interfaces/Falcon/BMS/FlightData2.cs
+++ b/Helios/Interfaces/Falcon/BMS/FlightData2.cs
@@ -41,9 +41,8 @@ namespace GadrocsWorkshop.Helios.Interfaces.Falcon.BMS
         public float oilPressure2; // Ownship Oil Pressure2 (Percent 0-100)
         public byte navMode;  // current mode selected for HSI/eHSI (added in BMS4)
         public float aauz; // Ownship barometric altitude given by AAU (depends on calibration)
-        public int AltCalReading;	// barometric altitude calibration (depends on CalType)
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)TacanSources.NUMBER_OF_SOURCES)]
         public TacanBits[] tacanInfo;      // Tacan band/mode settings for UFC and AUX COMM
-
+        public int AltCalReading;	// barometric altitude calibration (depends on CalType)
     }
 }

--- a/Helios/Interfaces/Falcon/BMS/FlightData2.cs
+++ b/Helios/Interfaces/Falcon/BMS/FlightData2.cs
@@ -41,7 +41,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.Falcon.BMS
         public float oilPressure2; // Ownship Oil Pressure2 (Percent 0-100)
         public byte navMode;  // current mode selected for HSI/eHSI (added in BMS4)
         public float aauz; // Ownship barometric altitude given by AAU (depends on calibration)
-
+        public int AltCalReading;	// barometric altitude calibration (depends on CalType)
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = (int)TacanSources.NUMBER_OF_SOURCES)]
         public TacanBits[] tacanInfo;      // Tacan band/mode settings for UFC and AUX COMM
 


### PR DESCRIPTION
Fixes for F-16 Altimeter Gauge pressure readout

updated BMSFalconDataExport to support new shared memory readings for Barometric Altitude & calibrated pressure.