### PR TITLE
restructured ResetMonitors

### DIFF
--- a/Helios/HeliosSerializer.cs
+++ b/Helios/HeliosSerializer.cs
@@ -302,7 +302,7 @@ namespace GadrocsWorkshop.Helios
                 }
             } else
             {
-                ConfigManager.LogManager.LogDebug("Binding Source Reference Unresolved: " + xmlReader.GetAttribute("Source"));
+                ConfigManager.LogManager.LogError("Binding Source Reference Unresolved: " + xmlReader.GetAttribute("Source"));
             }
             xmlReader.Read();
 
@@ -326,7 +326,7 @@ namespace GadrocsWorkshop.Helios
             }
             else
             {
-                ConfigManager.LogManager.LogDebug("Binding Target Reference Unresolved: " + xmlReader.GetAttribute("Target"));
+                ConfigManager.LogManager.LogError("Binding Target Reference Unresolved: " + xmlReader.GetAttribute("Target"));
             }
             xmlReader.Read();
             switch (xmlReader.Name)

--- a/Helios/UndoManager.cs
+++ b/Helios/UndoManager.cs
@@ -167,5 +167,22 @@ namespace GadrocsWorkshop.Helios
                 _batch = null;
             }
         }
+
+        /// <summary>
+        /// roll back everything in the currently open batch, not redoable
+        /// </summary>
+        public void UndoBatch()
+        {
+            _working = true;
+            try
+            {
+                _batch?.Undo();
+            }
+            finally
+            {
+                _working = false;
+                _batch = null;
+            }
+        }
     }
 }

--- a/Profile Editor/MainWindow.xaml.cs
+++ b/Profile Editor/MainWindow.xaml.cs
@@ -887,11 +887,13 @@ namespace GadrocsWorkshop.Helios.ProfileEditor
                     ResetRemovedMonitor(profile, monitorIndex, item, localMonitors.Length);
                 }
 
-                // pass2: place all controls that were temporarily lifted
+                // pass2: place all controls that were temporarily lifted and
+                // copy over any settings from source to target monitors
                 foreach (MonitorResetItem item in resetDialog.MonitorResets)
                 {
                     ConfigManager.LogManager.LogDebug($"Placing controls for old monitor {item.OldMonitor.Name} onto Monitor {item.NewMonitor + 1}");
                     Dispatcher.Invoke(DispatcherPriority.Background, new Action<Monitor>(item.PlaceControls), profile.Monitors[item.NewMonitor]);
+                    Dispatcher.Invoke(DispatcherPriority.Background, new Action<Monitor>(item.CopySettings), profile.Monitors[item.NewMonitor]);
                 }
 
                 ConfigManager.UndoManager.CloseBatch();
@@ -924,6 +926,7 @@ namespace GadrocsWorkshop.Helios.ProfileEditor
             ConfigManager.LogManager.LogDebug($"Adding Monitor {monitorIndex + 1}");
             Monitor monitor = new Monitor(display);
             monitor.Name = $"Monitor {monitorIndex + 1}";
+            monitor.FillBackground = false;
             ConfigManager.UndoManager.AddUndoItem(new AddMonitorUndoEvent(profile, monitor));
             Dispatcher.Invoke(DispatcherPriority.Background, new Action<Monitor>(profile.Monitors.Add), monitor);
         }

--- a/Profile Editor/ViewModel/MonitorResetItem.cs
+++ b/Profile Editor/ViewModel/MonitorResetItem.cs
@@ -54,18 +54,7 @@ namespace GadrocsWorkshop.Helios.ProfileEditor.ViewModel
             {
                 return _oldMonitor;
             }
-            set
-            {
-                if ((_oldMonitor == null && value != null)
-                    || (_oldMonitor != null && !_oldMonitor.Equals(value)))
-                {
-                    Monitor oldValue = _oldMonitor;
-                    _oldMonitor = value;
-                    OnPropertyChanged("OldMonitor", oldValue, value, false);
-                }
-            }
         }
-
 
         public int NewMonitor
         {
@@ -105,6 +94,7 @@ namespace GadrocsWorkshop.Helios.ProfileEditor.ViewModel
         {
             Monitor display = ConfigManager.DisplayManager.Displays[_oldId];
 
+            // change the size of the monitor to match the local display
             OldMonitor.Top = display.Top;
             OldMonitor.Left = display.Left;
             OldMonitor.Width = display.Width;
@@ -114,7 +104,9 @@ namespace GadrocsWorkshop.Helios.ProfileEditor.ViewModel
             // REVISIT: this does not invalidate the profile preview's image of the monitor
             // after the last height change, so it shows the wrong height (height of old monitor)
 
+            // REVISIT: does this work if there is an orientation change?
             double scale = Math.Min(display.Width / _oldWidth, display.Height / _oldHeight);
+
             foreach (HeliosVisual visual in OldMonitor.Children)
             {
                 if (Scale)
@@ -134,13 +126,12 @@ namespace GadrocsWorkshop.Helios.ProfileEditor.ViewModel
             foreach (HeliosVisual visual in children)
             {
                 _controls.Add(visual);
-                _oldMonitor.Children.Remove(visual);
+                OldMonitor.Children.Remove(visual);
             }
         }
 
         public void PlaceControls(Monitor newMonitor)
         {
-
             double scale = Math.Min(newMonitor.Width / _oldWidth, newMonitor.Height / _oldHeight);
             foreach (HeliosVisual visual in _controls)
             {
@@ -163,6 +154,30 @@ namespace GadrocsWorkshop.Helios.ProfileEditor.ViewModel
                 {
                     CheckBounds(visual, newMonitor);
                 }
+            }
+        }
+
+        public void CopySettings(Monitor newMonitor)
+        {
+            if (_controls.Count == 0)
+            {
+                // nothing transferred
+                // NOTE: this also covers the case where the source and target monitor are the same
+                return;
+            }
+            if (!OldMonitor.FillBackground)
+            {
+                // the transferred controls require a transparent monitor,
+                // so we have to set this, even if it gets combined with controls
+                // from opaque monitors
+                newMonitor.FillBackground = false;
+            }
+            if (OldMonitor.AlwaysOnTop)
+            {
+                // even if we combine multiple monitors,
+                // in order to have any of the source monitors on top, we 
+                // need to set the combined monitor on top
+                newMonitor.AlwaysOnTop = true;
             }
         }
 

--- a/Profile Editor/ViewModel/MonitorResetItem.cs
+++ b/Profile Editor/ViewModel/MonitorResetItem.cs
@@ -111,6 +111,9 @@ namespace GadrocsWorkshop.Helios.ProfileEditor.ViewModel
             OldMonitor.Height = display.Height;
             OldMonitor.Orientation = display.Orientation;
 
+            // REVISIT: this does not invalidate the profile preview's image of the monitor
+            // after the last height change, so it shows the wrong height (height of old monitor)
+
             double scale = Math.Min(display.Width / _oldWidth, display.Height / _oldHeight);
             foreach (HeliosVisual visual in OldMonitor.Children)
             {


### PR DESCRIPTION
this is a proposed restructuring of the Reset Monitors code for #194

This is just the restructuring of the code.  I am thinking of adding on the config copy in this item, so I am not calling this done.  Let's first see if we are ok with this change.

In the original code, some reset items were never processed when multiple monitors were removed. The root cause was the sloppy use of the vague variable 'i' as both the index into the monitors collections and the reset items, and these two stop being aligned when we pull out the first of the extra monitors (when monitor 4 is removed, the old monitor 5 becomes index 4, but its reset item is still at index 5).

now performs undo if exception is thrown half way through the process