### PR TITLE
Fix String Device Landing Gear

### DIFF
--- a/Helios/Interfaces/Falcon/AlliedForces/AlliedForcesDataExporter.cs
+++ b/Helios/Interfaces/Falcon/AlliedForces/AlliedForcesDataExporter.cs
@@ -87,7 +87,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.Falcon.AlliedForces
                 SetValue("Engine", "fuel flow", new BindingValue(_lastFlightData.fuelFlow));
                 SetValue("Engine", "rpm", new BindingValue(_lastFlightData.rpm));
                 SetValue("Engine", "ftit", new BindingValue(Ftit(_lastFlightData.ftit, _lastFlightData.rpm)));
-                SetValue("Landging Gear", "position", new BindingValue(_lastFlightData.gearPos != 0d)); // TODO Landging should be changed Landing
+                SetValue("Landing Gear", "position", new BindingValue(_lastFlightData.gearPos != 0d));
                 SetValue("General", "speed brake position", new BindingValue(_lastFlightData.speedBrake));
                 SetValue("General", "speed brake indicator", new BindingValue(_lastFlightData.speedBrake > 0d));
                 SetValue("EPU", "fuel", new BindingValue(_lastFlightData.epuFuel));

--- a/Helios/Interfaces/Falcon/BMS/BMSFalconDataExporter.cs
+++ b/Helios/Interfaces/Falcon/BMS/BMSFalconDataExporter.cs
@@ -160,7 +160,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.Falcon.BMS
                 SetValue("Engine", "fuel flow", new BindingValue(_lastFlightData.fuelFlow));
                 SetValue("Engine", "rpm", new BindingValue(_lastFlightData.rpm));
                 SetValue("Engine", "ftit", new BindingValue(_lastFlightData.ftit * 100));
-                SetValue("Landging Gear", "position", new BindingValue(_lastFlightData.gearPos != 0d)); // TODO Landging should be changed Landing
+                SetValue("Landing Gear", "position", new BindingValue(_lastFlightData.gearPos != 0d));
                 SetValue("General", "speed brake position", new BindingValue(_lastFlightData.speedBrake));
                 SetValue("General", "speed brake indicator", new BindingValue(_lastFlightData.speedBrake > 0d));
                 SetValue("EPU", "fuel", new BindingValue(_lastFlightData.epuFuel));

--- a/Helios/Interfaces/Falcon/OpenFalcon/OpenFalconDataExporter.cs
+++ b/Helios/Interfaces/Falcon/OpenFalcon/OpenFalconDataExporter.cs
@@ -79,7 +79,7 @@ namespace GadrocsWorkshop.Helios.Interfaces.Falcon.OpenFalcon
                 SetValue("Engine", "fuel flow", new BindingValue(_lastFlightData.fuelFlow));
                 SetValue("Engine", "rpm", new BindingValue(_lastFlightData.rpm));
                 SetValue("Engine", "ftit", new BindingValue(Ftit(_lastFlightData.ftit, _lastFlightData.rpm)));
-                SetValue("Landging Gear", "position", new BindingValue(_lastFlightData.gearPos != 0d)); // TODO Landging should be changed Landing
+                SetValue("Landing Gear", "position", new BindingValue(_lastFlightData.gearPos != 0d)); 
                 SetValue("General", "speed brake position", new BindingValue(_lastFlightData.speedBrake));
                 SetValue("General", "speed brake indicator", new BindingValue(_lastFlightData.speedBrake > 0d));
                 SetValue("EPU", "fuel", new BindingValue(_lastFlightData.epuFuel));


### PR DESCRIPTION
The Landing Gear string device for the string name position had been changed between Gadroc/Helios 1.3 and Helios 1.4. Somewhere along the way a typo was introduced. Fixed this issue so now string name 'position' shows up under the rest of string device 'Landing Gear'